### PR TITLE
Avatar components

### DIFF
--- a/front/antd-demo/src/App.jsx
+++ b/front/antd-demo/src/App.jsx
@@ -2,7 +2,7 @@ import "./App.css";
 import { Layout } from "antd";
 import PageHeader from "./layout/header/PageHeader";
 import UserAvatar from "./modules/wiki/avatar/user-avatar";
-import AuthorAvatar from "./modules/wiki/avatar/author-avatar";
+import RoleAvatar from "./modules/wiki/avatar/role-avatar";
 
 function App() {
   // Sólo muestra el header con un contenido random
@@ -15,7 +15,7 @@ function App() {
         <Layout.Content className="app-content">
           <h1>Contenido</h1>
           <UserAvatar/>
-          <AuthorAvatar
+          <RoleAvatar
             image="https://yt3.googleusercontent.com/qk8AlThEihBfAmEgkgJRnKG1sQbsuSDfG4ejMS8o_dxDBkVM_1sKIB4fsHoVDvj_w9gjoxO_jQ=s900-c-k-c0x00ffffff-no-rj"
             username="TheGrefg"
             role="Author"

--- a/front/antd-demo/src/App.jsx
+++ b/front/antd-demo/src/App.jsx
@@ -14,10 +14,7 @@ function App() {
 
         <Layout.Content className="app-content">
           <h1>Contenido</h1>
-          <UserAvatar
-            image="https://yt3.googleusercontent.com/qk8AlThEihBfAmEgkgJRnKG1sQbsuSDfG4ejMS8o_dxDBkVM_1sKIB4fsHoVDvj_w9gjoxO_jQ=s900-c-k-c0x00ffffff-no-rj"
-            username="TheGrefg"
-          />
+          <UserAvatar/>
           <AuthorAvatar
             image="https://yt3.googleusercontent.com/qk8AlThEihBfAmEgkgJRnKG1sQbsuSDfG4ejMS8o_dxDBkVM_1sKIB4fsHoVDvj_w9gjoxO_jQ=s900-c-k-c0x00ffffff-no-rj"
             username="TheGrefg"

--- a/front/antd-demo/src/App.jsx
+++ b/front/antd-demo/src/App.jsx
@@ -1,24 +1,32 @@
-import './App.css'
+import "./App.css";
 import { Layout } from "antd";
-import PageHeader from './layout/header/PageHeader'
+import PageHeader from "./layout/header/PageHeader";
+import UserAvatar from "./modules/wiki/avatar/user-avatar";
+import AuthorAvatar from "./modules/wiki/avatar/author-avatar";
 
 function App() {
   // Sólo muestra el header con un contenido random
   // Todo el contenido debe ser children del header
   return (
     <>
-    
-    <Layout className="app-layout">
-      <PageHeader/>
+      <Layout className="app-layout">
+        <PageHeader />
 
-      <Layout.Content className="app-content">
-        <h1>Contenido</h1>
-      </Layout.Content>
-
-    </Layout>
-      
+        <Layout.Content className="app-content">
+          <h1>Contenido</h1>
+          <UserAvatar
+            image="https://yt3.googleusercontent.com/qk8AlThEihBfAmEgkgJRnKG1sQbsuSDfG4ejMS8o_dxDBkVM_1sKIB4fsHoVDvj_w9gjoxO_jQ=s900-c-k-c0x00ffffff-no-rj"
+            username="TheGrefg"
+          />
+          <AuthorAvatar
+            image="https://yt3.googleusercontent.com/qk8AlThEihBfAmEgkgJRnKG1sQbsuSDfG4ejMS8o_dxDBkVM_1sKIB4fsHoVDvj_w9gjoxO_jQ=s900-c-k-c0x00ffffff-no-rj"
+            username="TheGrefg"
+            role="Author"
+          />
+        </Layout.Content>
+      </Layout>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/front/antd-demo/src/layout/header/MainHeader.jsx
+++ b/front/antd-demo/src/layout/header/MainHeader.jsx
@@ -8,7 +8,6 @@ import {
 import PropTypes from "prop-types";
 import "./PageHeader.css";
 import Title from "antd/es/typography/Title";
-import React from "react";
 
 const FilterIcon = () => {
   return (

--- a/front/antd-demo/src/modules/wiki/avatar/author-avatar.jsx
+++ b/front/antd-demo/src/modules/wiki/avatar/author-avatar.jsx
@@ -1,5 +1,5 @@
+import { UserOutlined } from '@ant-design/icons';
 import { Avatar, Flex, Typography } from 'antd';
-import Title from 'antd/es/typography/Title';
 
 const { Text } = Typography;
 
@@ -7,13 +7,14 @@ const AuthorAvatar = ({ image, username, role }) => {
   return (
     <Flex gap='small' align='center'>
       <Avatar
-        src={image} // Ajusta el tamaño del avatar
+        icon = {image ? null : <UserOutlined/>}
+        src={image}
         size={64}
-        alt={`${username}'s avatar`}
+        alt={`${username ? username : "Username"}'s avatar`}
       />
       <Flex vertical>
-        <Text style={{fontSize: '20px', fontWeight: 'bold'}}>{username}</Text>
-        <Text >{role}</Text>
+        <Text style={{fontSize: '20px', fontWeight: 'bold'}}>{username ? username : "Username"}</Text>
+        <Text >{role ? role : "User Role"}</Text>
       </Flex>
     </Flex>
   );

--- a/front/antd-demo/src/modules/wiki/avatar/author-avatar.jsx
+++ b/front/antd-demo/src/modules/wiki/avatar/author-avatar.jsx
@@ -1,0 +1,23 @@
+import { Avatar, Flex, Typography } from 'antd';
+import Title from 'antd/es/typography/Title';
+
+const { Text } = Typography;
+
+const AuthorAvatar = ({ image, username, role }) => {
+  return (
+    <Flex gap='small' align='center'>
+      <Avatar
+        src={image} // Ajusta el tamaño del avatar
+        size={64}
+        alt={`${username}'s avatar`}
+      />
+      <Flex vertical>
+        <Text style={{fontSize: '20px', fontWeight: 'bold'}}>{username}</Text>
+        <Text >{role}</Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+
+export default AuthorAvatar;

--- a/front/antd-demo/src/modules/wiki/avatar/role-avatar.jsx
+++ b/front/antd-demo/src/modules/wiki/avatar/role-avatar.jsx
@@ -3,7 +3,7 @@ import { Avatar, Flex, Typography } from 'antd';
 
 const { Text } = Typography;
 
-const AuthorAvatar = ({ image, username, role }) => {
+const RoleAvatar = ({ image, username, role }) => {
   return (
     <Flex gap='small' align='center'>
       <Avatar
@@ -21,4 +21,4 @@ const AuthorAvatar = ({ image, username, role }) => {
 };
 
 
-export default AuthorAvatar;
+export default RoleAvatar;

--- a/front/antd-demo/src/modules/wiki/avatar/user-avatar.jsx
+++ b/front/antd-demo/src/modules/wiki/avatar/user-avatar.jsx
@@ -1,18 +1,19 @@
-import { Avatar, Flex, Typography } from 'antd';
+import { Avatar, Flex, Typography } from "antd";
+import { UserOutlined } from "@ant-design/icons";
 
 const { Text } = Typography;
 
 const UserAvatar = ({ image, username }) => {
   return (
-    <Flex gap='small' align='center'>
+    <Flex gap="small" align="center">
       <Avatar
+        icon = {image ? null : <UserOutlined />} // Si no hay imagen, muestra el icono de usuario
         src={image} // Ajusta el tamaño del avatar
-        alt={`${username}'s avatar`}
+        alt={`${username ? username : "Username"}'s avatar`}
       />
-      <Text >{username}</Text>
+      <Text>{username ? username : "Username"}</Text>
     </Flex>
   );
 };
-
 
 export default UserAvatar;

--- a/front/antd-demo/src/modules/wiki/avatar/user-avatar.jsx
+++ b/front/antd-demo/src/modules/wiki/avatar/user-avatar.jsx
@@ -1,0 +1,18 @@
+import { Avatar, Flex, Typography } from 'antd';
+
+const { Text } = Typography;
+
+const UserAvatar = ({ image, username }) => {
+  return (
+    <Flex gap='small' align='center'>
+      <Avatar
+        src={image} // Ajusta el tamaño del avatar
+        alt={`${username}'s avatar`}
+      />
+      <Text >{username}</Text>
+    </Flex>
+  );
+};
+
+
+export default UserAvatar;


### PR DESCRIPTION
Created a couple components related to the user avatars:

- user-avatar: The user info that will be shown on the articles list component given the image source and the username
- role-avatar: The user info that will be shown on the wikis description. It allows to specify a role.

![image](https://github.com/user-attachments/assets/0fb711c6-4847-4741-9c32-34a1fecdc4b9)

Tested in the App.jsx file